### PR TITLE
Improve signup form and email verification flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ const Welcome = lazy(() => import("./pages/Welcome"));
 const Home = lazy(() => import("./pages/Home"));
 const Login = lazy(() => import("./pages/Login"));
 const SignUp = lazy(() => import("./pages/SignUp"));
+const EmailConfirmed = lazy(() => import("./pages/EmailConfirmed"));
 import NotFound from "./pages/NotFound";
 import BookAppointment from "./pages/client/BookAppointment";
 import RebookAppointment from "./pages/client/RebookAppointment";
@@ -56,6 +57,7 @@ const App = () => {
         <Route path="/welcome" element={<Welcome />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<SignUp />} />
+        <Route path="/email-confirmed" element={<EmailConfirmed />} />
         
         {/* Protected routes */}
         <Route element={<ProtectedRoute />}>

--- a/src/pages/EmailConfirmed.tsx
+++ b/src/pages/EmailConfirmed.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+const EmailConfirmed = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const timer = setTimeout(() => navigate("/login"), 3000);
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  return (
+    <div className="welcome-screen">
+      <div className="welcome-container">
+        <div className="welcome-text-box max-w-sm mx-auto p-3 text-center space-y-4">
+          <p className="welcome-tagline">האימייל שלך אושר בהצלחה!</p>
+          <Button asChild className="w-full h-8">
+            <Link to="/login">להתחברות</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EmailConfirmed;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -18,23 +18,23 @@ const Login = () => {
     setLoading(true);
 
     try {
-      const { error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,
       });
 
       if (error) {
         setError(error.message || "האימייל או הסיסמה שגויים");
+      } else if (data.user && !data.user.email_confirmed_at) {
+        await supabase.auth.signOut();
+        setError("יש לאשר את האימייל לפני התחברות.");
       } else {
-        // The onAuthStateChange listener in SessionContext will handle the redirect
-        // and profile fetching. We just need to wait for the session to be established.
-        // Navigating immediately can sometimes cause race conditions.
-        // A simple navigation to home should be fine as ProtectedRoute will handle it.
         navigate("/");
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("An unexpected error occurred during login:", e);
-      setError(e.message || "אירעה שגיאה בלתי צפויה. אנא נסה שוב.");
+      const message = e instanceof Error ? e.message : "אירעה שגיאה בלתי צפויה. אנא נסה שוב.";
+      setError(message);
     } finally {
       setLoading(false);
     }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -12,7 +12,10 @@ const SignUp = () => {
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [birthDate, setBirthDate] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [birthDay, setBirthDay] = useState("");
+  const [birthMonth, setBirthMonth] = useState("");
+  const [birthYear, setBirthYear] = useState("");
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -25,7 +28,7 @@ const SignUp = () => {
       setError("יש לאשר את תנאי השימוש והסכמה לדיוור.");
       return;
     }
-    if (!firstName || !lastName || !phone || !email || !birthDate) {
+    if (!firstName || !lastName || !phone || !email || !birthDay || !birthMonth || !birthYear) {
       setError("יש למלא את כל השדות.");
       return;
     }
@@ -33,6 +36,13 @@ const SignUp = () => {
       setError("סיסמה חייבת לכלול 6 תווים לפחות");
       return;
     }
+    if (password !== confirmPassword) {
+      setError("הסיסמאות אינן תואמות");
+      return;
+    }
+
+    const formattedBirthDate = `${birthYear.padStart(4, "0")}-${birthMonth.padStart(2, "0")}-${birthDay.padStart(2, "0")}`;
+
 
     setLoading(true);
 
@@ -45,10 +55,10 @@ const SignUp = () => {
             first_name: firstName,
             last_name: lastName,
             phone: phone,
-            birth_date: birthDate,
+            birth_date: formattedBirthDate,
             full_name: `${firstName} ${lastName}`,
           },
-          emailRedirectTo: `${window.location.origin}/login`,
+          emailRedirectTo: `${import.meta.env.VITE_SITE_URL || window.location.origin}/email-confirmed`,
         },
       });
       
@@ -64,9 +74,10 @@ const SignUp = () => {
         alert("נשלח אליך אימייל אימות. יש לאשר אותו כדי להשלים את ההרשמה.");
         navigate("/login");
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error("An unexpected error occurred during sign up:", e);
-      setError(e.message || "אירעה שגיאה בלתי צפויה. אנא נסה שוב.");
+      const message = e instanceof Error ? e.message : "אירעה שגיאה בלתי צפויה. אנא נסה שוב.";
+      setError(message);
     } finally {
       setLoading(false);
     }
@@ -75,7 +86,7 @@ const SignUp = () => {
   return (
     <div className="welcome-screen">
       <div className="welcome-container">
-        <div className="welcome-text-box max-w-sm mx-auto p-3">
+        <div className="welcome-text-box max-w-sm md:max-w-md mx-auto p-3">
           <form onSubmit={handleSignUp} className="space-y-2">
             <div className="space-y-1">
               <Label htmlFor="firstName" className="welcome-tagline text-sm">שם פרטי</Label>
@@ -124,15 +135,42 @@ const SignUp = () => {
               />
             </div>
             <div className="space-y-1">
-              <Label htmlFor="birthDate" className="welcome-tagline text-sm">תאריך לידה</Label>
-              <Input
-                id="birthDate"
-                type="date"
-                value={birthDate}
-                onChange={(e) => setBirthDate(e.target.value)}
-                required
-                className="h-8"
-              />
+              <Label className="welcome-tagline text-sm">תאריך לידה</Label>
+              <div className="grid grid-cols-3 gap-2">
+                <Input
+                  id="birthDay"
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="יום"
+                  maxLength={2}
+                  value={birthDay}
+                  onChange={(e) => setBirthDay(e.target.value)}
+                  required
+                  className="h-8 text-center"
+                />
+                <Input
+                  id="birthMonth"
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="חודש"
+                  maxLength={2}
+                  value={birthMonth}
+                  onChange={(e) => setBirthMonth(e.target.value)}
+                  required
+                  className="h-8 text-center"
+                />
+                <Input
+                  id="birthYear"
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="שנה"
+                  maxLength={4}
+                  value={birthYear}
+                  onChange={(e) => setBirthYear(e.target.value)}
+                  required
+                  className="h-8 text-center"
+                />
+              </div>
             </div>
             <div className="space-y-1">
               <Label htmlFor="password" className="welcome-tagline text-sm">סיסמה</Label>
@@ -141,6 +179,18 @@ const SignUp = () => {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="new-password"
+                className="h-8"
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="confirmPassword" className="welcome-tagline text-sm">אימות סיסמה</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
                 required
                 autoComplete="new-password"
                 className="h-8"
@@ -160,7 +210,7 @@ const SignUp = () => {
               </Label>
             </div>
             <div className="text-xs text-white bg-black/30 p-2 rounded mt-2">
-              <b>דיסקליימר:</b> בהרשמה לאתר אתה מאשר קבלת דיוור, עדכונים ומידע שיווקי בהתאם לחוק הספאם. תוכל להסיר את עצמך מרשימת התפוצה בכל עת.
+              בהרשמה לאתר אתה מאשר קבלת דיוור, עדכונים ומידע שיווקי בהתאם לחוק הספאם. תוכל להסיר את עצמך מרשימת התפוצה בכל עת.
             </div>
             {error && <p className="text-red-500 text-xs welcome-tagline bg-black/30 p-1 rounded">{error}</p>}
             <Button type="submit" className="w-full h-8 mt-2" disabled={loading}>


### PR DESCRIPTION
## Summary
- Allow manual birth date input without calendar and add password confirmation
- Require confirmed email before login and redirect verification to thank-you page
- Clean up disclaimer text and add email confirmation page

## Testing
- `pnpm lint` *(fails: Unexpected any in unrelated files)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b7f4c86dbc8322aa60eb3aefa29504