### PR TITLE
Add custom Supabase signup confirmation template

### DIFF
--- a/supabase/templates/confirm_signup.html
+++ b/supabase/templates/confirm_signup.html
@@ -1,0 +1,16 @@
+Subject: BarberTor - אישור הרשמה
+<!DOCTYPE html>
+<html lang="he">
+  <head>
+    <meta charset="UTF-8" />
+    <title>BarberTor - אישור הרשמה</title>
+  </head>
+  <body>
+    <h1>ברוכים הבאים ל-BarberTor</h1>
+    <p>תודה שנרשמתם ל-BarberTor. כדי להשלים את ההרשמה, נא אשרו את כתובת המייל שלכם בלחיצה על הקישור הבא:</p>
+    <p><a href="{{ .ConfirmationURL }}">אישור הרשמה</a></p>
+    <p>אם הקישור לא נפתח, תוכלו להעתיק ולהדביק את הכתובת הזו בשורת הכתובת בדפדפן שלכם:<br/>
+    {{ .ConfirmationURL }}</p>
+    <p>נתראה בקרוב,<br/>צוות BarberTor</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Supabase email template for confirming signup with branded subject and content

## Testing
- `pnpm lint` *(fails: Unexpected any and other lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b80680daf48322bccd2a9826c47ea9