### PR TITLE
Trigger push registration after login and enforce token uniqueness

### DIFF
--- a/supabase/migrations/20240730000000_add_unique_token_constraint_to_device_tokens.sql
+++ b/supabase/migrations/20240730000000_add_unique_token_constraint_to_device_tokens.sql
@@ -1,0 +1,2 @@
+alter table public.device_tokens
+  add constraint device_tokens_token_unique unique (token);


### PR DESCRIPTION
## Summary
- request notification permission before fetching push token
- upsert device tokens and add unique constraint on token
- initialize push notifications only once user session exists

## Testing
- `pnpm lint` *(fails: Unexpected any, no-empty-object-type, no-require-imports in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b917aae54c832289700e00d27e5092