### PR TITLE
Add daily appointment reminder function and toggle

### DIFF
--- a/src/components/admin/NotificationsManager.tsx
+++ b/src/components/admin/NotificationsManager.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -9,7 +11,33 @@ export function NotificationsManager() {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [userIds, setUserIds] = useState("");
+  const [remindersEnabled, setRemindersEnabled] = useState(false);
   const { toast } = useToast();
+
+  useEffect(() => {
+    supabase
+      .from("business_settings")
+      .select("appointment_reminders_enabled")
+      .single()
+      .then(({ data }) => {
+        if (data) setRemindersEnabled(data.appointment_reminders_enabled || false);
+      });
+  }, []);
+
+  const toggleReminders = async (checked: boolean) => {
+    setRemindersEnabled(checked);
+    const { error } = await supabase
+      .from("business_settings")
+      .update({ appointment_reminders_enabled: checked })
+      .eq("id", 1);
+
+    if (error) {
+      setRemindersEnabled(!checked);
+      toast({ title: "שגיאה בעדכון", description: error.message, variant: "destructive" });
+    } else {
+      toast({ title: checked ? "תזכורות הופעלו" : "תזכורות כובו" });
+    }
+  };
 
   const send = async () => {
     const ids = userIds
@@ -32,6 +60,12 @@ export function NotificationsManager() {
   return (
     <div className="space-y-4">
       <h2 className="text-2xl font-semibold">התראות פוש</h2>
+      <div className="flex items-center space-x-2 space-x-reverse">
+        <Switch id="reminders-switch" checked={remindersEnabled} onCheckedChange={toggleReminders} />
+        <Label htmlFor="reminders-switch" className="text-lg">
+          {remindersEnabled ? "תזכורות יומיות מופעלות" : "תזכורות יומיות כבויות"}
+        </Label>
+      </div>
       <Input placeholder="כותרת" value={title} onChange={(e) => setTitle(e.target.value)} />
       <Textarea placeholder="תוכן" value={body} onChange={(e) => setBody(e.target.value)} />
       <Input

--- a/supabase/functions/send-appointment-reminders/index.ts
+++ b/supabase/functions/send-appointment-reminders/index.ts
@@ -1,0 +1,51 @@
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(() => new Response("ok"));
+
+Deno.cron("daily-appointment-reminders", "0 20 * * *", async () => {
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  const { data: settings } = await supabase
+    .from("business_settings")
+    .select("appointment_reminders_enabled")
+    .single();
+
+  if (!settings?.appointment_reminders_enabled) return;
+
+  const now = new Date();
+  const start = new Date(now);
+  start.setDate(start.getDate() + 1);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setHours(23, 59, 59, 999);
+
+  const { data: appointments, error } = await supabase
+    .from("appointments")
+    .select("user_id")
+    .gte("start_time", start.toISOString())
+    .lt("start_time", end.toISOString());
+
+  if (error) {
+    console.error("Error fetching appointments", error);
+    return;
+  }
+
+  const userIds = Array.from(new Set((appointments || []).map(a => a.user_id)));
+  if (userIds.length === 0) return;
+
+  const { error: fnError } = await supabase.functions.invoke("send-notification", {
+    body: {
+      title: "תזכורת לתור",
+      body: "יש לך תור מחר",
+      user_ids: userIds,
+    },
+  });
+
+  if (fnError) {
+    console.error("Error sending notifications", fnError);
+  }
+});

--- a/supabase/migrations/20240801000001_add_appointment_reminders_enabled.sql
+++ b/supabase/migrations/20240801000001_add_appointment_reminders_enabled.sql
@@ -1,0 +1,1 @@
+alter table business_settings add column appointment_reminders_enabled boolean not null default false;


### PR DESCRIPTION
## Summary
- schedule edge function `send-appointment-reminders` to notify users of next-day appointments at 20:00
- add `appointment_reminders_enabled` setting with migration
- allow admins to toggle daily reminders in NotificationsManager

## Testing
- `pnpm lint` *(fails: Unexpected any and other existing repo errors)*
- `npx eslint src/components/admin/NotificationsManager.tsx supabase/functions/send-appointment-reminders/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b91a551c888322a81c461bc15c330b