### PR TITLE
Use Web Push for notification delivery

### DIFF
--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { sendWebPush } from "https://deno.land/x/webpush@1.0.3/mod.ts";
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -14,25 +15,39 @@ serve(async (req) => {
   const { title, body, user_ids } = await req.json();
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
   );
 
-  const { data: tokens } = await supabase
-    .from("device_tokens")
-    .select("token")
+  const publicKey = Deno.env.get("VAPID_PUBLIC_KEY")!;
+  const privateKey = Deno.env.get("VAPID_PRIVATE_KEY")!;
+
+  const { data: subscriptions } = await supabase
+    .from("push_subscriptions")
+    .select("id, subscription")
     .in("user_id", user_ids);
 
-  await fetch("https://fcm.googleapis.com/fcm/send", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `key=${Deno.env.get("FCM_SERVER_KEY")}`,
-    },
-    body: JSON.stringify({
-      notification: { title, body },
-      registration_ids: tokens?.map((t) => t.token) ?? [],
-    }),
-  });
+  for (const { id, subscription } of subscriptions ?? []) {
+    try {
+      const res = await sendWebPush(
+        subscription,
+        JSON.stringify({ title, body }),
+        { vapidKeys: { publicKey, privateKey } },
+      );
+      if (res.status === 410) {
+        await supabase.from("push_subscriptions").delete().eq("id", id);
+      }
+    } catch (error) {
+      const { status, statusCode } = error as {
+        status?: number;
+        statusCode?: number;
+      };
+      if ((status ?? statusCode) === 410) {
+        await supabase.from("push_subscriptions").delete().eq("id", id);
+      } else {
+        console.error("Failed to send web push", error);
+      }
+    }
+  }
 
   return new Response(JSON.stringify({ success: true }), {
     headers: { "Access-Control-Allow-Origin": "*" },


### PR DESCRIPTION
## Summary
- send notifications using Web Push instead of FCM
- store VAPID keys in environment and clean up invalid subscriptions

## Testing
- `pnpm exec eslint supabase/functions/send-notification/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b939e2fa288322aaccccdf41c7b2bf