### PR TITLE
Store push subscription details and remove device tokens table

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -44,9 +44,16 @@ async function initPush() {
       userVisibleOnly: true,
       applicationServerKey: import.meta.env.VITE_VAPID_PUBLIC_KEY,
     });
-    await supabase
-      .from("push_subscriptions")
-      .upsert({ subscription: subscription.toJSON() });
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    const { endpoint, keys } = subscription.toJSON();
+    await supabase.from('push_subscriptions').upsert({
+      user_id: user?.id,
+      endpoint,
+      p256dh: keys.p256dh,
+      auth: keys.auth,
+    });
   } catch (error) {
     console.error("Push notification setup failed", error);
   }

--- a/supabase/migrations/20240730000000_add_unique_token_constraint_to_device_tokens.sql
+++ b/supabase/migrations/20240730000000_add_unique_token_constraint_to_device_tokens.sql
@@ -1,2 +1,0 @@
-alter table public.device_tokens
-  add constraint device_tokens_token_unique unique (token);


### PR DESCRIPTION
## Summary
- upsert push subscriptions with user_id, endpoint, and key fields
- remove unused device_tokens migration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b93b0e9f248322b6b5d899b4434564