### PR TITLE
feat: add supabase storage helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Welcome to your Dyad app
+
+## Supabase Storage
+
+Uploaded files are stored in the `BarberTor` bucket on Supabase Storage.
+
+Use the helper functions to upload files and get their public URLs:
+
+```ts
+import { uploadFile, getPublicUrl } from '@/integrations/supabase/storage';
+
+const path = `example/${file.name}`;
+await uploadFile('BarberTor', path, file);
+const publicUrl = getPublicUrl('BarberTor', path);
+```

--- a/src/integrations/supabase/storage.ts
+++ b/src/integrations/supabase/storage.ts
@@ -1,0 +1,11 @@
+import { supabase } from './client';
+
+export async function uploadFile(bucket: string, path: string, file: File) {
+  const { data, error } = await supabase.storage.from(bucket).upload(path, file);
+  if (error) throw error;
+  return data;
+}
+
+export function getPublicUrl(bucket: string, path: string) {
+  return supabase.storage.from(bucket).getPublicUrl(path).data.publicUrl;
+}


### PR DESCRIPTION
## Summary
- add reusable Supabase storage helpers
- document BarberTor storage bucket usage

## Testing
- `pnpm lint` *(fails: Unexpected any, etc.)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b93baddbac8322973d863807e1b469