### PR TITLE
feat: add admin RLS policy for notification settings

### DIFF
--- a/supabase/migrations/20250910000000_add_admin_policy.sql
+++ b/supabase/migrations/20250910000000_add_admin_policy.sql
@@ -1,0 +1,16 @@
+-- Allow administrators full access to notification_settings table
+create policy "Admins can manage notification_settings"
+  on notification_settings
+  for all
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid() and profiles.is_admin = true
+    )
+  )
+  with check (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid() and profiles.is_admin = true
+    )
+  );


### PR DESCRIPTION
## Summary
- allow admins full CRUD on notification_settings through RLS

## Testing
- `pnpm lint` (fails: Unexpected any, etc.)
- `npx supabase migration up` (fails: connection refused)


------
https://chatgpt.com/codex/tasks/task_e_68b9437543588322bcfa1e8e7fae8577