### PR TITLE
refactor: store push subscription as json

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -47,12 +47,9 @@ async function initPush() {
     const {
       data: { user },
     } = await supabase.auth.getUser();
-    const { endpoint, keys } = subscription.toJSON();
     await supabase.from('push_subscriptions').upsert({
       user_id: user?.id,
-      endpoint,
-      p256dh: keys.p256dh,
-      auth: keys.auth,
+      subscription: subscription.toJSON(),
     });
   } catch (error) {
     console.error("Push notification setup failed", error);

--- a/supabase/functions/send-notification/index.ts
+++ b/supabase/functions/send-notification/index.ts
@@ -28,8 +28,10 @@ serve(async (req) => {
 
   for (const { id, subscription } of subscriptions ?? []) {
     try {
+      const parsedSubscription =
+        typeof subscription === "string" ? JSON.parse(subscription) : subscription;
       const res = await sendWebPush(
-        subscription,
+        parsedSubscription,
         JSON.stringify({ title, body }),
         { vapidKeys: { publicKey, privateKey } },
       );

--- a/supabase/migrations/20250911000000_migrate_push_subscriptions_to_json.sql
+++ b/supabase/migrations/20250911000000_migrate_push_subscriptions_to_json.sql
@@ -1,0 +1,13 @@
+alter table push_subscriptions
+  add column if not exists subscription jsonb;
+
+update push_subscriptions
+set subscription = jsonb_build_object(
+  'endpoint', endpoint,
+  'keys', jsonb_build_object('p256dh', p256dh, 'auth', auth)
+)
+where subscription is null;
+
+alter table push_subscriptions drop column if exists endpoint;
+alter table push_subscriptions drop column if exists p256dh;
+alter table push_subscriptions drop column if exists auth;


### PR DESCRIPTION
## Summary
- store entire push subscription in single JSON column
- parse JSON subscription when sending web push notifications
- migrate existing push subscription data to new JSON column

## Testing
- `pnpm lint` *(fails: Unexpected any & require() style import)*

------
https://chatgpt.com/codex/tasks/task_e_68b9449e7c108322bff139609667fcc1