### PR TITLE
feat: add customizable appointment reminders

### DIFF
--- a/supabase/migrations/20250912000000_add_appointment_reminder_settings.sql
+++ b/supabase/migrations/20250912000000_add_appointment_reminder_settings.sql
@@ -1,0 +1,8 @@
+alter table business_settings
+  add column evening_reminder_time time,
+  add column evening_reminder_message text,
+  add column morning_reminder_start_time time,
+  add column morning_reminder_end_time time,
+  add column morning_reminder_message text,
+  add column three_hours_reminder_time time,
+  add column three_hours_reminder_message text;


### PR DESCRIPTION
## Summary
- add migration for reminder time and messages in `business_settings`
- extend admin notifications manager with inputs for evening, morning, and 3-hour reminders

## Testing
- `pnpm lint` *(fails: Unexpected any, no-empty-object-type, etc.)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b945cd7ec48322aef1d78f70025259