### PR TITLE
Add reminder log tracking and admin view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import ProtectedRoute from "./components/auth/ProtectedRoute";
 import ClientsManagementPage from "./pages/admin/ClientsManagementPage";
 import SettingsPage from "./pages/admin/SettingsPage";
 const ServicesManagementPage = lazy(() => import("./pages/admin/ServicesManagementPage"));
+import ReminderLogsPage from "./pages/admin/ReminderLogsPage";
 
 const App = () => {
   const { loading: authLoading } = useSession();
@@ -75,6 +76,7 @@ const App = () => {
             <Route path="appointments" element={<AppointmentsManagementPage />} />
             <Route path="clients" element={<ClientsManagementPage />} />
             <Route path="services" element={<ServicesManagementPage />} />
+            <Route path="reminder-logs" element={<ReminderLogsPage />} />
             <Route path="settings" element={<SettingsPage />} />
           </Route>
         </Route>

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
-import { LayoutDashboard, Calendar, Mail, Menu, X, LogOut, ListTodo, Users, Settings, Scissors } from "lucide-react";
+import { LayoutDashboard, Calendar, Mail, Menu, X, LogOut, ListTodo, Users, Settings, Scissors, Bell } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { useSession } from "@/contexts/SessionContext";
@@ -12,6 +12,7 @@ const navItems = [
   { href: "/admin/appointments", label: "ניהול תורים", icon: ListTodo },
   { href: "/admin/clients", label: "ניהול לקוחות", icon: Users },
   { href: "/admin/services", label: "ניהול שירותים", icon: Scissors },
+  { href: "/admin/reminder-logs", label: "לוג תזכורות", icon: Bell },
   { href: "/admin/settings", label: "הגדרות", icon: Settings },
 ];
 

--- a/src/components/admin/ReminderLogs.tsx
+++ b/src/components/admin/ReminderLogs.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/ui/table";
+
+interface ReminderLog {
+  id: string;
+  appointment_id: string;
+  type: string;
+  status: string;
+  sent_at: string;
+  appointments?: { start_time: string | null };
+}
+
+export const ReminderLogs = () => {
+  const [logs, setLogs] = useState<ReminderLog[]>([]);
+
+  useEffect(() => {
+    supabase
+      .from("reminder_logs")
+      .select("id, appointment_id, type, status, sent_at, appointments(start_time)")
+      .order("sent_at", { ascending: false })
+      .then(({ data }) => setLogs(data || []));
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>לוג תזכורות</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>תור</TableHead>
+              <TableHead>סוג</TableHead>
+              <TableHead>זמן שליחה</TableHead>
+              <TableHead>סטטוס</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {logs.map((log) => (
+              <TableRow key={log.id}>
+                <TableCell>
+                  {log.appointments?.start_time
+                    ? new Date(log.appointments.start_time).toLocaleString()
+                    : log.appointment_id}
+                </TableCell>
+                <TableCell>{log.type}</TableCell>
+                <TableCell>{new Date(log.sent_at).toLocaleString()}</TableCell>
+                <TableCell>{log.status}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/pages/admin/ReminderLogsPage.tsx
+++ b/src/pages/admin/ReminderLogsPage.tsx
@@ -1,0 +1,7 @@
+import { ReminderLogs } from "@/components/admin/ReminderLogs";
+
+const ReminderLogsPage = () => {
+  return <ReminderLogs />;
+};
+
+export default ReminderLogsPage;

--- a/supabase/functions/send-upcoming-reminders/index.ts
+++ b/supabase/functions/send-upcoming-reminders/index.ts
@@ -77,6 +77,20 @@ Deno.cron("upcoming-appointment-reminders", "*/15 * * * *", async () => {
           if (fnError) {
             console.error("Error sending morning reminders", fnError);
           }
+
+          const status = fnError ? "failed" : "sent";
+          const logs = (appointments || [])
+            .filter((a) => subscribedUserIds.includes(a.user_id))
+            .map((a) => ({
+              appointment_id: a.id,
+              user_id: a.user_id,
+              type: "morning",
+              status,
+              sent_at: new Date().toISOString(),
+            }));
+          if (logs.length > 0) {
+            await supabase.from("reminder_logs").insert(logs);
+          }
         }
 
         const appointmentIds = (appointments || []).map((a) => a.id);
@@ -128,6 +142,20 @@ Deno.cron("upcoming-appointment-reminders", "*/15 * * * *", async () => {
 
         if (fnError) {
           console.error("Error sending three hours reminders", fnError);
+        }
+
+        const status = fnError ? "failed" : "sent";
+        const logs = (appointments || [])
+          .filter((a) => subscribedUserIds.includes(a.user_id))
+          .map((a) => ({
+            appointment_id: a.id,
+            user_id: a.user_id,
+            type: "three_hours",
+            status,
+            sent_at: new Date().toISOString(),
+          }));
+        if (logs.length > 0) {
+          await supabase.from("reminder_logs").insert(logs);
         }
       }
 

--- a/supabase/migrations/20250913000000_create_reminder_logs_table.sql
+++ b/supabase/migrations/20250913000000_create_reminder_logs_table.sql
@@ -1,0 +1,22 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists reminder_logs (
+  id uuid primary key default gen_random_uuid(),
+  appointment_id uuid references appointments(id) on delete cascade,
+  user_id uuid references profiles(id) on delete cascade,
+  type text not null,
+  status text not null,
+  sent_at timestamptz not null default now()
+);
+
+alter table reminder_logs enable row level security;
+
+create policy "Admins can read reminder_logs"
+  on reminder_logs
+  for select
+  using (
+    exists (
+      select 1 from profiles
+      where profiles.id = auth.uid() and profiles.is_admin = true
+    )
+  );


### PR DESCRIPTION
## Summary
- create reminder_logs table for storing reminder dispatch records
- log reminder sends from cron functions
- add admin ReminderLogs page to view reminder history

## Testing
- `pnpm lint` (fails: Unexpected any in existing files)
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b947cb32e48322862502a82c6bd5c0