### PR TITLE
Ensure business settings row exists and use upsert

### DIFF
--- a/src/components/admin/BusinessHoursManager.tsx
+++ b/src/components/admin/BusinessHoursManager.tsx
@@ -95,8 +95,7 @@ export const BusinessHoursManager = () => {
     setIsSaving(true);
     const { error } = await supabase
       .from("business_settings")
-      .update({ working_hours: workingHours })
-      .eq("id", 1);
+      .upsert({ id: 1, working_hours: workingHours });
 
     if (error) {
       showError(`שגיאה בשמירת ההגדרות: ${error.message}`);

--- a/src/components/admin/NotificationsManager.tsx
+++ b/src/components/admin/NotificationsManager.tsx
@@ -159,8 +159,7 @@ export const NotificationsManager = () => {
     setRemindersEnabled(checked);
     const { error } = await supabase
       .from("business_settings")
-      .update({ appointment_reminders_enabled: checked })
-      .eq("id", 1);
+      .upsert({ id: 1, appointment_reminders_enabled: checked });
 
     if (error) {
       setRemindersEnabled(!checked);
@@ -173,7 +172,8 @@ export const NotificationsManager = () => {
   const saveReminderSettings = async () => {
     const { error } = await supabase
       .from("business_settings")
-      .update({
+      .upsert({
+        id: 1,
         evening_reminder_time: eveningTime || null,
         evening_reminder_message: eveningMessage || null,
         morning_reminder_start_time: morningStart || null,
@@ -181,8 +181,7 @@ export const NotificationsManager = () => {
         morning_reminder_message: morningMessage || null,
         three_hours_reminder_time: threeHoursTime || null,
         three_hours_reminder_message: threeHoursMessage || null,
-      })
-      .eq("id", 1);
+      });
 
     if (error) {
       showError(`שגיאה בעדכון: ${error.message}`);

--- a/src/lib/initBusinessSettings.ts
+++ b/src/lib/initBusinessSettings.ts
@@ -1,0 +1,43 @@
+import { supabase } from "@/integrations/supabase/client";
+
+const defaultWorkingHours: Record<string, { start: string; end: string }[] | null> = {
+  sunday: [{ start: "09:00", end: "18:00" }],
+  monday: [{ start: "09:00", end: "18:00" }],
+  tuesday: [{ start: "09:00", end: "18:00" }],
+  wednesday: [{ start: "09:00", end: "18:00" }],
+  thursday: [{ start: "09:00", end: "18:00" }],
+  friday: [{ start: "09:00", end: "14:00" }],
+  saturday: null,
+};
+
+const defaultPolicy = {
+  cancellation_hours_before: 12,
+  rebooking_hours_before: 12,
+  cancellation_grace_period_minutes: 30,
+  rebooking_grace_period_minutes: 30,
+};
+
+export async function ensureBusinessSettings() {
+  const { data, error } = await supabase
+    .from("business_settings")
+    .select("id")
+    .maybeSingle();
+
+  if (error) {
+    console.error("Failed to check business settings", error);
+    return;
+  }
+
+  if (!data) {
+    const { error: insertError } = await supabase.from("business_settings").insert({
+      id: 1,
+      working_hours: defaultWorkingHours,
+      appointment_reminders_enabled: false,
+      ...defaultPolicy,
+    });
+
+    if (insertError) {
+      console.error("Failed to create default business settings", insertError);
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import { Toaster } from "@/components/ui/toaster"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { supabase } from "@/integrations/supabase/client"
+import { ensureBusinessSettings } from "@/lib/initBusinessSettings"
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
@@ -31,6 +32,8 @@ Sentry.init({
 });
 
 const queryClient = new QueryClient();
+
+ensureBusinessSettings();
 
 async function initPush() {
   try {


### PR DESCRIPTION
## Summary
- Create initializer to insert default business_settings row if missing
- Switch notifications and business hours managers to upsert settings

## Testing
- `pnpm lint` *(fails: Unexpected any & other lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b94a2473148322a5afb643289f5b32