### PR TITLE
Use VAPID key for push subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ const publicUrl = getPublicUrl('BarberTor', path);
    ```bash
    npx web-push generate-vapid-keys
    ```
-3. Save the keys in your environment:
+3. Save the keys in your environment (Base64URL encoded without padding or whitespace):
    ```bash
    # .env.local
-   VITE_VAPID_PUBLIC_KEY=<public_key>
+   VITE_VAPID_PUBLIC_KEY=<base64url_public_key>
 
    # Supabase function secrets
-   VAPID_PUBLIC_KEY=<public_key>
+   VAPID_PUBLIC_KEY=<base64url_public_key>
    VAPID_PRIVATE_KEY=<private_key>
    ```
 


### PR DESCRIPTION
## Summary
- add `urlBase64ToUint8Array` helper to convert VAPID key
- convert `VITE_VAPID_PUBLIC_KEY` and use it for `applicationServerKey`
- document Base64URL formatting for VAPID keys

## Testing
- `pnpm lint` *(fails: Unexpected any / require import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b95891fba48322ae18b03f54abe788